### PR TITLE
Fix crashes from RDMA connection handshakes

### DIFF
--- a/include/seastar/net/rdma.hh
+++ b/include/seastar/net/rdma.hh
@@ -117,8 +117,6 @@ struct EndPoint {
     static int StringToGID(const sstring& strGID, union ibv_gid& result);
 };
 
-class RDMAConnectionError : std::exception {};
-
 class RDMAConnection : public weakly_referencable<RDMAConnection> {
 public:
     future<Buffer> recv();


### PR DESCRIPTION
Crashes were triggered when there were both incoming and outgoing RDMA connection requests. The incoming requests were improperly overwriting the handshake lookup, so when an outgoing request tried to complete the QP setup, it was encountering a null or invalid QP pointer.

After this fix 100 warehouse TPC-C test passed 4 times consecutively.

Also removed thrown exceptions from slow thread QP operations, which were not being caught as expected.